### PR TITLE
feat: 🌞 add `async` handler support in `APIView`

### DIFF
--- a/examples/reusable_views.py
+++ b/examples/reusable_views.py
@@ -18,7 +18,7 @@ class ReusableReadView(APIView):
         super().__init__(
             name=name,
             methods=["GET"],
-            path="/{id}/reusable",  # Not clashing with "/{id}" path of ReadView
+            path="/{id}/reusable",
             response_status=200,
             response_body=response_body,
             model=model,
@@ -38,7 +38,7 @@ class ReusableAsyncReadView(APIView):
         super().__init__(
             name=name,
             methods=["GET"],
-            path="/{id}/reusable/async",  # Not clashing with "/{id}" path of ReadView
+            path="/{id}/reusable/async",
             response_status=200,
             response_body=response_body,
             model=model,

--- a/examples/reusable_views.py
+++ b/examples/reusable_views.py
@@ -1,9 +1,9 @@
 from typing import Optional, Type
 from uuid import UUID
 
-import django.http
 import pydantic
 from django.db import models
+from django.http import HttpRequest
 
 from ninja_crud.views import APIView
 
@@ -18,11 +18,31 @@ class ReusableReadView(APIView):
         super().__init__(
             name=name,
             methods=["GET"],
-            path="/{id}/reusable",
+            path="/{id}/reusable",  # Not clashing with "/{id}" path of ReadView
             response_status=200,
             response_body=response_body,
             model=model,
         )
 
-    def handler(self, request: django.http.HttpRequest, id: UUID) -> models.Model:
+    def handler(self, request: HttpRequest, id: UUID) -> models.Model:
         return self.model.objects.get(id=id)
+
+
+class ReusableAsyncReadView(APIView):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        model: Optional[Type[models.Model]] = None,
+        response_body: Optional[Type[pydantic.BaseModel]] = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            methods=["GET"],
+            path="/{id}/reusable/async",  # Not clashing with "/{id}" path of ReadView
+            response_status=200,
+            response_body=response_body,
+            model=model,
+        )
+
+    async def handler(self, request: HttpRequest, id: UUID) -> models.Model:
+        return await self.model.objects.aget(id=id)

--- a/examples/tests/test_department_views.py
+++ b/examples/tests/test_department_views.py
@@ -56,7 +56,7 @@ class TestDepartmentViewSet(APITestCase):
     def test_read_department(self):
         self.assertScenariosSucceed(
             method="GET",
-            path="/api/departments/{id}/reusable",
+            path="/api/departments/{id}",
             scenarios=[
                 APIViewTestScenario(
                     path_parameters={"id": self.department_1.id},
@@ -155,6 +155,48 @@ class TestDepartmentViewSet(APITestCase):
                     path_parameters={"id": self.department_1.id},
                     request_body={"first_name": "first_name"},
                     expected_response_status=HTTPStatus.BAD_REQUEST,
+                ),
+            ],
+        )
+
+    def test_reusable_read_department(self):
+        self.assertScenariosSucceed(
+            method="GET",
+            path="/api/departments/{id}/reusable",
+            scenarios=[
+                APIViewTestScenario(
+                    path_parameters={"id": self.department_1.id},
+                    expected_response_status=HTTPStatus.OK,
+                    expected_response_body_type=DepartmentOut,
+                    expected_response_body={
+                        "id": str(self.department_1.id),
+                        "title": self.department_1.title,
+                    },
+                ),
+                APIViewTestScenario(
+                    path_parameters={"id": uuid.uuid4()},
+                    expected_response_status=HTTPStatus.NOT_FOUND,
+                ),
+            ],
+        )
+
+    def test_reusable_async_read_department(self):
+        self.assertScenariosSucceed(
+            method="GET",
+            path="/api/departments/{id}/reusable/async",
+            scenarios=[
+                APIViewTestScenario(
+                    path_parameters={"id": self.department_1.id},
+                    expected_response_status=HTTPStatus.OK,
+                    expected_response_body_type=DepartmentOut,
+                    expected_response_body={
+                        "id": str(self.department_1.id),
+                        "title": self.department_1.title,
+                    },
+                ),
+                APIViewTestScenario(
+                    path_parameters={"id": uuid.uuid4()},
+                    expected_response_status=HTTPStatus.NOT_FOUND,
                 ),
             ],
         )

--- a/examples/views/department_views.py
+++ b/examples/views/department_views.py
@@ -2,14 +2,12 @@ from typing import List
 
 from ninja import Router
 
+from examples import reusable_views
 from examples.models import Department, Employee
-from examples.reusable_views import ReusableReadView
 from examples.schemas import DepartmentIn, DepartmentOut, EmployeeIn, EmployeeOut
 from ninja_crud import views, viewsets
 
 router = Router()
-
-ReusableReadView(model=Department, response_body=DepartmentOut).add_view_to(router)
 
 
 class DepartmentViewSet(viewsets.APIViewSet):
@@ -38,4 +36,13 @@ class DepartmentViewSet(viewsets.APIViewSet):
         init_model=lambda request, path_parameters: Employee(
             department_id=path_parameters.id
         ),
+    )
+
+    reusable_read_department = reusable_views.ReusableReadView(
+        model=Department,
+        response_body=DepartmentOut,
+    )
+    reusable_async_read_department = reusable_views.ReusableAsyncReadView(
+        model=Department,
+        response_body=DepartmentOut,
     )


### PR DESCRIPTION
# Add support for async handlers in `APIView` subclasses

> [!WARNING]
While this PR provides an elegant solution for supporting async views in the APIView base class, it **DOES NOT** yet include async implementations for the built-in CRUD views. These will be addressed in a future PR to ensure they are implemented correctly and optimally.

## Release Plan

- **Version 0.6.1**: This PR will be included in the upcoming v0.6.1 release. This minor release will allow users to start defining custom async views as soon as possible, leveraging the new async capabilities of the `APIView` class.

- **Version 0.7.0**: The async implementations of built-in CRUD views are planned for v0.7.0, which is expected to be released in several weeks. This major release will provide a complete async experience for Django Ninja CRUD users.

This change **significantly** expands the capabilities of Django Ninja CRUD, allowing developers to leverage asynchronous programming where appropriate in their API views. By releasing the async `APIView` support early in v0.6.1, I'm giving developers the tools to start experimenting with and implementing async views immediately, while I work on providing full async support for built-in CRUD operations in the near future.