### PR TITLE
change path default to "/{int:id}"

### DIFF
--- a/src/ninja_crud/views/delete_view.py
+++ b/src/ninja_crud/views/delete_view.py
@@ -75,7 +75,7 @@ class DeleteView(APIView):
         self,
         name: Optional[str] = None,
         methods: Union[list[str], set[str], None] = None,
-        path: str = "/{id}",
+        path: str = "/{int:id}",
         response_status: int = 204,
         response_body: Any = None,
         model: Optional[type[Model]] = None,

--- a/src/ninja_crud/views/read_view.py
+++ b/src/ninja_crud/views/read_view.py
@@ -75,7 +75,7 @@ class ReadView(APIView):
         self,
         name: Optional[str] = None,
         methods: Union[list[str], set[str], None] = None,
-        path: str = "/{id}",
+        path: str = "/{int:id}",
         response_status: int = 200,
         response_body: Any = None,
         model: Optional[type[Model]] = None,

--- a/src/ninja_crud/views/update_view.py
+++ b/src/ninja_crud/views/update_view.py
@@ -88,7 +88,7 @@ class UpdateView(APIView):
         self,
         name: Optional[str] = None,
         methods: Union[list[str], set[str], None] = None,
-        path: str = "/{id}",
+        path: str = "/{int:id}",
         response_status: int = 200,
         response_body: Any = None,
         model: Optional[type[Model]] = None,


### PR DESCRIPTION
The lack a type in the default argument messes up existing routing, and `int` seems like a reasonable default. Can also get this working getting a type from the model using the ninja mapping, but I haven't gotten that cleanly working yet.